### PR TITLE
fix: handle 'split' being called on undefined

### DIFF
--- a/src/url-parameter-append.spec.ts
+++ b/src/url-parameter-append.spec.ts
@@ -131,4 +131,19 @@ describe('urlParameterAppend', () => {
       expect(result).toEqual('http://example.com/?updated=true&added=yes');
     });
   });
+
+  describe('edge cases', () => {
+    it('should default url to empty string if no url is defined', () => {
+      // @ts-ignore
+      const result = urlParameterAppend(undefined as any, 'param', 'value');
+
+      expect(result).toEqual('?param=value');
+    });
+
+    it('should default url to empty string if no url is defined', () => {
+      const result = urlParameterAppend(null as any, 'param', 'value');
+
+      expect(result).toEqual('?param=value');
+    });
+  });
 });

--- a/src/url-parameter-append.ts
+++ b/src/url-parameter-append.ts
@@ -18,7 +18,7 @@ export default function urlParameterAppend(url: string, ...args: any[]): string 
   }
 
   // tslint:disable-next-line:prefer-const
-  let [modifiedUrl, ...fragment] = url.split('#');
+  let [modifiedUrl, ...fragment] = (url ?? '').split('#');
 
   for (let i = 0; i < args.length; i += 2) {
     const param = args[i];


### PR DESCRIPTION
fix: handle 'split' being called on undefined when invalid url value specified